### PR TITLE
fix: yaml `safe_load` used

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,11 +34,11 @@ def parse_args_and_config():
     # parse config file
     if not args.test:
         with open(os.path.join('configs', args.config), 'r') as f:
-            config = yaml.load(f)
+            config = yaml.safe_load(f)
         new_config = dict2namespace(config)
     else:
         with open(os.path.join(args.log, 'config.yml'), 'r') as f:
-            config = yaml.load(f)
+            config = yaml.safe_load(f)
         new_config = config
 
     if not args.test:


### PR DESCRIPTION
Compliance issue. In the latest `yaml` version, use `yaml.safe_load` instead of `yaml.load`

https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation